### PR TITLE
fixed time bar acting weird

### DIFF
--- a/src/components/VotesPopup.vue
+++ b/src/components/VotesPopup.vue
@@ -54,17 +54,25 @@ export default {
     components: {
         DisplayHeader,
     },
+    data() {
+        return {
+            interval: null,
+        }
+    },
     methods: {
         startTimer() {
             let timer = 1000;
-            let interval = setInterval(() => {
+            
+            this.interval = setInterval(() => {
                 timer--;
+
                 this.updateProgressBar(timer);
 
                 if (timer <= 0) {
+                    clearInterval(this.interval);
+                    this.updateProgressBar(1000);
                     this.$parent.votes.visible = false;
                     this.$parent.session.visible = true;
-                    clearInterval(interval);
                 }
             }, 60);
         },
@@ -75,6 +83,7 @@ export default {
         },
 
 		dismissVotesPopup() {
+            clearInterval(this.interval);
 			this.$parent.votes.visible = false;
 			this.$parent.session.visible = true;
 		}
@@ -82,6 +91,7 @@ export default {
     mounted() {
         EVENTBUS.$on("results", () => {
             this.startTimer();
+            this.updateProgressBar(1000);
             this.$parent.votes.visible = true;
             this.$parent.session.visible = false;
         });


### PR DESCRIPTION
1. get in a working session.
2. go through round 1 and 2.
3. after choosing a user to assign. the result popup will show up.
Which is now 1 minute long, and has a dismiss button (X button at the top right of the popup).
4. check if it's actually around 1 minute long.
the time can differ per browser since it's javascript
5. check if the dismiss button works.
Just click the X button at the top right.
The popup should close and go back to the session.