### PR TITLE
link back button to correct url path when in /passwordreset

### DIFF
--- a/src/views/PasswordReset.vue
+++ b/src/views/PasswordReset.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="passwordreset">
         <div class="interface">
-            <router-link to="/profile" id="backButton"
+            <router-link to="/login" id="backButton"
                 ><svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="32"


### PR DESCRIPTION
0. Zorg dat je uitgelogd bent
1. Open de password reset pagina vanuit de login pagina
2. De terug knop zal linken naar /login, ipv /profile

Voorheen linkte het naar /profile. Maar omdat de router ziet dat je nog niet ingelogd was werd je als nog naar /profile doorgestuurd.